### PR TITLE
Configure fzf to enable live previews

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -37,6 +37,18 @@ alias pbpaste='xclip -selection clipboard -o'
 alias g='git'
 
 
+#  ================================= FZF =================================
+export FZF_DEFAULT_OPTS='
+  -m -i
+  --bind ctrl-d:page-down,ctrl-u:page-up
+  --preview "[[ $(file --mime {}) =~ binary ]] &&
+                 echo {} is a binary file ||
+                 (bat --style "numbers,changes" --color=always {} ||
+                  head -500 {}) 2> /dev/null"
+  --preview-window right:35%
+'
+
+
 #  ================================= OTHER =================================
 if [ -z "$TMUX" ]; then
   tmux

--- a/.vim/.vimrc
+++ b/.vim/.vimrc
@@ -228,3 +228,22 @@ function! CloseHiddenBuffers()
   endfor
   echon "Deleted " . l:tally . " buffers"
 endfun
+
+" FZF Config
+function! s:build_quickfix_list(lines)
+  call setqflist(map(copy(a:lines), '{ "filename": v:val }'))
+  copen
+  cc
+endfunction
+let g:fzf_action = {
+  \ 'ctrl-q': function('s:build_quickfix_list'),
+  \ 'ctrl-t': 'tab split',
+  \ 'ctrl-x': 'split',
+  \ 'ctrl-v': 'vsplit' }
+let g:fzf_layout = {'down': '45%'}
+command! -bang -nargs=* Ag
+  \ call fzf#vim#ag(<q-args>, fzf#vim#with_preview('right:35%'))
+" Immediately trigger a search for the current keyword if there is one
+nnoremap <expr> <leader>g (expand("<cword>") ==? "") ? ":Ag " : ":Ag \<C-r>\<C-w><CR>"
+" Immediately trigger a search for the current selection if there is one
+xnoremap <leader>g "zy:exe "Ag ".@z.""<CR>


### PR DESCRIPTION
I've left off most of the configuration specific to my setup (eg using `ripgrep` instead of `ag`, and specifying `FZF_DEFAULT_COMMAND` so that it traverses the entire directory instead of just files tracked by git.
